### PR TITLE
Return exit code instead of exiting in #run 

### DIFF
--- a/lib/komplement/base.rb
+++ b/lib/komplement/base.rb
@@ -26,8 +26,7 @@ module Komplement
 
     # returns 0 on no offenses, else 2
     def run
-      unknown = find_offenses
-      exit process_output(unknown)
+      process_output(find_offenses)
     end
 
     def find_offenses

--- a/lib/komplement/base.rb
+++ b/lib/komplement/base.rb
@@ -79,7 +79,7 @@ module Komplement
     # @param unknown_h are the unknown elements that may have been detected
     def process_output(unknown_h)
       if unknown_h.empty?
-        $stderr.puts 'No problematic html found'.green.bold
+        $stdout.puts 'No problematic html found'.green.bold
         return EXIT_SUCCESS
       end
 


### PR DESCRIPTION
This lets the user handle failure/success when using `#run` without exiting the process.
This also prints to stdout instead of stderr on success.

Maybe I misunderstood and `#find_offenses` is meant to be used instead.
